### PR TITLE
BACKLOG-13064: Define new site var for redux initialization only

### DIFF
--- a/src/main/resources/root.jsp
+++ b/src/main/resources/root.jsp
@@ -20,6 +20,10 @@
 
     <script type="text/javascript">
         Object.assign(window.contextJsParameters, {
+            // Theses values are for GWT only
+            siteKey: '${defaultSite.siteKey}',
+            siteUuid: '${defaultSite.identifier}',
+
             version: '<%= Jahia.VERSION %>',
             contextPath: '${contextPath}',
             user: {
@@ -29,8 +33,7 @@
                 path: '${currentUser.localPath}'
             },
             config: ${config},
-            siteKey: '${defaultSite.siteKey}',
-            siteUuid: '${defaultSite.identifier}',
+            site: '${defaultSite.siteKey}',
             urlbase: '<c:url value="/modules/appshell/${appName}"/>'
         });
     </script>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-13064

## Description

As siteKey is modified by GWT from time to time (and sometimes before redux init, depending on load time)