### PR TITLE
BACKLOG-13291: Restrict app-shell access to privileged users

### DIFF
--- a/src/main/java/org/jahia/modules/appshell/Main.java
+++ b/src/main/java/org/jahia/modules/appshell/Main.java
@@ -51,7 +51,9 @@ import org.jahia.osgi.BundleUtils;
 import org.jahia.osgi.FrameworkService;
 import org.jahia.registries.ServicesRegistry;
 import org.jahia.services.content.JCRSessionFactory;
+import org.jahia.services.content.decorator.JCRUserNode;
 import org.jahia.services.sites.JahiaSite;
+import org.jahia.services.usermanager.JahiaGroupManagerService;
 import org.jahia.services.usermanager.JahiaUser;
 import org.jahia.services.usermanager.JahiaUserManagerService;
 import org.jahia.settings.SettingsBean;
@@ -89,6 +91,13 @@ public class Main extends HttpServlet {
             JahiaUser currentUser = JCRSessionFactory.getInstance().getCurrentUser();
             if (JahiaUserManagerService.isGuest(currentUser)) {
                 response.sendRedirect(Jahia.getContextPath() + "/cms/login?redirect=" + response.encodeRedirectURL(request.getRequestURI()));
+                return;
+            }
+
+            // Restrict access to privileged users
+            JCRUserNode userNode = JahiaUserManagerService.getInstance().lookupUserByPath(currentUser.getLocalPath());
+            if (!userNode.isMemberOfGroup(null, JahiaGroupManagerService.PRIVILEGED_GROUPNAME)) {
+                response.sendError(HttpServletResponse.SC_FORBIDDEN);
                 return;
             }
 


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/BACKLOG-13291

## Description

This does mimic what is done in WelcomeServlet to restrict access to the dashboard.

If user is not a privileged one then respond with a HTTP 403 (which will display an error page).
Without this, the call to JahiaSitesService.getDefaultSite(JCRSessionWrapper) is throwing a PathNotFoundException, and an empty page is rendered.
