### PR TITLE
MOON-53: Adds webpack rules to support css files coming from Moonstone

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "@jahia/data-helper": "^0.0.24",
         "@jahia/design-system-kit": "^1.1.7",
         "@jahia/icons": "^1.1.1",
-        "@jahia/moonstone": "^0.16.1",
+        "@jahia/moonstone": "^0.16.2-canary.0e01963",
         "@jahia/react-material": "^2.1.2",
         "@jahia/ui-extender": "0.4.20-canary.c6b54a1.0",
         "apollo-cache-inmemory": "^1.6.5",

--- a/webpack.libraries.config.js
+++ b/webpack.libraries.config.js
@@ -95,24 +95,6 @@ module.exports = (env, argv) => {
                     enforce: 'pre'
                 },
                 {
-                    test: /\.scss$/i,
-                    sideEffects: true,
-                    use: [
-                        'style-loader',
-                        // Translates CSS into CommonJS
-                        {
-                            loader: 'css-loader',
-                            options: {
-                                modules: {
-                                    mode: 'local'
-                                }
-                            }
-                        },
-                        // Compiles Sass to CSS
-                        'sass-loader'
-                    ]
-                },
-                {
                     test: /\.css$/i,
                     sideEffects: true,
                     use: [

--- a/webpack.libraries.config.js
+++ b/webpack.libraries.config.js
@@ -113,6 +113,14 @@ module.exports = (env, argv) => {
                     ]
                 },
                 {
+                    test: /\.css$/i,
+                    sideEffects: true,
+                    use: [
+                        'style-loader',
+                        'css-loader'
+                    ]
+                },
+                {
                     test: /\.(woff(2)?|ttf|eot|svg)(\?v=\d+\.\d+\.\d+)?$/,
                     use: [{
                         loader: 'file-loader',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1062,10 +1062,10 @@
     mdi-material-ui "^5.10.0"
     recompose "^0.30.0"
 
-"@jahia/moonstone@^0.16.1":
-  version "0.16.1"
-  resolved "https://npm.jahia.com/@jahia%2fmoonstone/-/moonstone-0.16.1.tgz#0258fad3c09e32a4d92bb6341e153e5596d5f276"
-  integrity sha512-xGGCcvnG/RBT4LDV3aKfjv5/Tw0VLxWo8YsloA+dah8Ux7rOer6Eoq8AxsKLpIaXfB1+tQ7kdbtnRP3Rs6RFtg==
+"@jahia/moonstone@^0.16.2-canary.0e01963":
+  version "0.16.2-canary.0e01963"
+  resolved "https://npm.jahia.com/@jahia%2fmoonstone/-/moonstone-0.16.2-canary.0e01963.tgz#baf3d46cd7424308f1ae56c8142e83c0009adf49"
+  integrity sha512-+hCgiW4mifk5xQEfyroiqAZjzHSuwta88ED50QsKgQpV2Q4SUYkGrpqHQD1H5BJAkTzfCz+QFQI5hwPgpSZQCg==
   dependencies:
     clsx "^1.0.4"
     prop-types "^15.7.2"


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/MOON-53

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

* Updates webpack.libraries.config.js so that css files coming from the new Moonstone build are supported