### PR TITLE
TECH-286: Added react-hooks and moonstone as singletons, rename exposed module

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -9,3 +9,14 @@ src/main
 node
 node_modules
 yarn-error.log
+/.circleci
+/.externalToolBuilders
+graphql.config.json
+graphql.schema.json
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+.yalc
+yalc.lock
+coverage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@jahia/app-shell",
-    "version": "1.4.0",
+    "version": "2.2.0",
     "scripts": {
         "build": "yarn webpack:appshell --mode=development",
         "prebuild:production": "yarn lint && yarn test",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -178,7 +178,7 @@ module.exports = (env, argv) => {
                 library: {type: 'var', name: 'appShellRemote'},
                 filename: 'remoteEntry.js',
                 exposes: {
-                    './src/javascript/bootstrap': './src/javascript/bootstrap'
+                    './bootstrap': './src/javascript/bootstrap'
                 },
                 shared: shared
             }),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,6 +31,7 @@ const sharedDeps = [
     // Apollo
     '@apollo/react-common',
     '@apollo/react-components',
+    '@apollo/react-hooks',
 
     // DEPRECATED JAHIA PACKAGES
     '@jahia/design-system-kit',
@@ -48,9 +49,11 @@ const singletonDeps = [
     'react-apollo',
     'react-redux',
     'redux',
+    '@jahia/moonstone',
     '@jahia/ui-extender',
     '@apollo/react-common',
-    '@apollo/react-components'
+    '@apollo/react-components',
+    '@apollo/react-hooks'
 ];
 
 const shared = {
@@ -175,7 +178,7 @@ module.exports = (env, argv) => {
                 library: {type: 'var', name: 'appShellRemote'},
                 filename: 'remoteEntry.js',
                 exposes: {
-                    './bootstrap': './src/javascript/bootstrap'
+                    './src/javascript/bootstrap': './src/javascript/bootstrap'
                 },
                 shared: shared
             }),


### PR DESCRIPTION

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/TECH-286

## Description

- Update version and npmignore, to prepare possible package publication
- Added libraries as singleton
- Renamed expose to be consistent with real path