### PR TITLE
Bump Moonstone version to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "@jahia/data-helper": "^1.0.0",
         "@jahia/design-system-kit": "^1.1.11",
         "@jahia/icons": "^1.1.1",
-        "@jahia/moonstone": "^1.0.0",
+        "@jahia/moonstone": "^1.1.0",
         "@jahia/moonstone-alpha": "^1.0.0",
         "@jahia/react-material": "^3.0.3",
         "@jahia/ui-extender": "^1.0.2",

--- a/src/javascript/compat.js
+++ b/src/javascript/compat.js
@@ -274,9 +274,9 @@ export default function (jahiaCommons) {
     jahiaCommons['4ea912277bb8352bf9f9'] = require('@jahia/moonstone/dist/components/Tab/Tab.css');
     jahiaCommons['6a29e22050d047120205'] = require('@jahia/moonstone/dist/components/Tab/Tab');
     jahiaCommons['0ce9201ce2d0106182df'] = require('@jahia/moonstone/dist/components/Tab/index');
-    jahiaCommons['bfeb21ad33ca1d415a98'] = require('@jahia/moonstone/dist/components/TabItem/TabItem.css');
-    jahiaCommons['0c0468d40d8e043dbdf7'] = require('@jahia/moonstone/dist/components/TabItem/TabItem');
-    jahiaCommons['5cb11776e556a5fff7ff'] = require('@jahia/moonstone/dist/components/TabItem/index');
+    jahiaCommons['bfeb21ad33ca1d415a98'] = require('@jahia/moonstone/dist/components/Tab/TabItem/TabItem.css');
+    jahiaCommons['0c0468d40d8e043dbdf7'] = require('@jahia/moonstone/dist/components/Tab/TabItem/TabItem');
+    jahiaCommons['5cb11776e556a5fff7ff'] = require('@jahia/moonstone/dist/components/Tab/TabItem/index');
     jahiaCommons['0e316a9b284b41ec43e0'] = require('@jahia/moonstone/dist/components/TreeView/ControlledTreeView');
     jahiaCommons['0c38be0a845c5868c5da'] = require('@jahia/moonstone/dist/components/TreeView/TreeView.css');
     jahiaCommons['c1f92759553e8cd55958'] = require('@jahia/moonstone/dist/components/TreeView/TreeView');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1140,10 +1140,10 @@
     react-day-picker "^7.4.8"
     webpack-node-externals "^2.5.2"
 
-"@jahia/moonstone@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@jahia/moonstone/-/moonstone-1.0.0.tgz#17c276579a8b53690cf59e53227c431b532b3fbd"
-  integrity sha512-e3/eZSjHgqDxtxIQQuBlbhOUCRa9wplN1SKEIorE/lMpieeT51hzwoR7rVNlirHw6ZDQhIZgdD938xq9VNigHQ==
+"@jahia/moonstone@^1.0.0", "@jahia/moonstone@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@jahia/moonstone/-/moonstone-1.1.0.tgz#5ca03a6ca55dec859033a0517b598f1a9d7e60d1"
+  integrity sha512-amBYoWF/cbxzxeAlZ+egf1bQIJhQaXSHqCFKBJRm1oXlPconTYDL0vfA8u8Ua/vU3WeZl8F4iQZ5tRvSzoVBCg==
   dependencies:
     "@babel/runtime" "^7.12.5"
     clsx "^1.1.1"


### PR DESCRIPTION
- Bump Moonstone version to 1.1.0
- Updated compat.js because TabItem folder in Moonstone was moved