### PR TITLE
TECH-420 Expose ApolloClient in window.jahia so that we can use it in Javascript app inits to populate registry

### DIFF
--- a/src/javascript/apollo/register.js
+++ b/src/javascript/apollo/register.js
@@ -3,7 +3,7 @@ import {registry} from '@jahia/ui-extender';
 import {ApolloProvider} from 'react-apollo';
 import {client} from './client';
 
-const apolloClient = client({
+export const apolloClient = client({
     contextPath: window.contextJsParameters.contextPath,
     useBatch: true,
     httpOptions: {batchMax: 20}

--- a/src/javascript/bootstrap.js
+++ b/src/javascript/bootstrap.js
@@ -1,5 +1,5 @@
 // Configuration
-const apolloClient = require('./apollo/register');
+const apolloClient = require('./apollo/register').apolloClient;
 require('./redux/register');
 
 // Global values to expose in Jahia library

--- a/src/javascript/bootstrap.js
+++ b/src/javascript/bootstrap.js
@@ -1,5 +1,5 @@
 // Configuration
-require('./apollo/register');
+const apolloClient = require('./apollo/register');
 require('./redux/register');
 
 // Global values to expose in Jahia library
@@ -17,5 +17,6 @@ export {
     i18n,
     uiExtender,
     moonstone,
-    modules
+    modules,
+    apolloClient
 };


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/TECH-420

## Description

In order to be able to perform GraphQL requests outside of the context of React components, for example to build registry entries from GraphQL responses, we need to be able to access the configured ApolloClient. 

The idea would be to modify the app-shell to expose the apolloclient the same way it currently exposes other resources such as i18n, uiExtender, moonstone and more.
## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

I have considered the following implications of my change: 

- [ X ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ X ] Performance
- [ X ] Migration
- [ X ] Code maintainability

## Documentation

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
