### PR TITLE
BACKLOG-20520: Fixed issue in test execution introduced in the latest commit

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,6 +1,7 @@
 name: Nightly Test run
 
 on:
+  workflow_dispatch:
   schedule:
     - cron:  '0 0 * * *'
 

--- a/package.json
+++ b/package.json
@@ -60,10 +60,13 @@
         "zen-observable": "^0.8.15"
     },
     "resolutions": {
+        "css-loader/loader-utils": "^1.4.2",
+        "file-loader/loader-utils": "^1.4.2",
         "graphql": "15.4.0",
         "@jahia/data-helper/graphql": "^15.4.0",
         "node-fetch": "^2.6.1",
         "minimist": "^1.2.6",
+        "style-loader/loader-utils": "^1.4.2",
         "watchpack": "^2.2.0"
     },
     "devDependencies": {
@@ -77,7 +80,7 @@
         "@jahia/eslint-config": "^1.1.0",
         "@jahia/test-framework": "^1.1.5",
         "babel-jest": "^28.1.0",
-        "babel-loader": "^8.2.1",
+        "babel-loader": "^8.2.5",
         "babel-plugin-lodash": "^3.3.4",
         "babel-plugin-transform-imports": "^1.5.1",
         "clean-webpack-plugin": "^1.0.0",

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM cypress/base:14
+FROM cypress/base:16.5.0
 
 RUN apt-get update && apt-get install -y jq
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2895,13 +2895,13 @@ babel-jest@^28.1.0:
     graceful-fs "^4.2.9"
     slash "^3.0.0"
 
-babel-loader@^8.2.1:
-  version "8.2.2"
-  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.2.2.tgz#9363ce84c10c9a40e6c753748e1441b60c8a0b81"
-  integrity sha512-JvTd0/D889PQBtUXJ2PXaKU/pjZDMtHA9V2ecm+eNRmmBCMR09a+fmpGTNwnJtFmFl5Ei7Vy47LjBb+L0wQ99g==
+babel-loader@^8.2.5:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.3.0.tgz#124936e841ba4fe8176786d6ff28add1f134d6a8"
+  integrity sha512-H8SvsMF+m9t15HNLMipppzkC+Y2Yq+v3SonZyU70RBL/h1gxPkH08Ot8pEE9Z4Kd+czyWJClmFS8qzIP9OZ04Q==
   dependencies:
     find-cache-dir "^3.3.1"
-    loader-utils "^1.4.0"
+    loader-utils "^2.0.0"
     make-dir "^3.1.0"
     schema-utils "^2.6.5"
 
@@ -6616,10 +6616,10 @@ loader-runner@^4.2.0:
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-4.2.0.tgz#d7022380d66d14c5fb1d496b89864ebcfd478384"
   integrity sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==
 
-loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
-  integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
+loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.2.tgz#29a957f3a63973883eb684f10ffd3d151fec01a3"
+  integrity sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==
   dependencies:
     big.js "^5.2.2"
     emojis-list "^3.0.0"


### PR DESCRIPTION
The error: 

```
  error @typescript-eslint/eslint-plugin@5.45.0: The engine "node" is incompatible with this module. Expected version "^12.22.0 || ^14.17.0 || >=16.0.0". Got "14.7.0"
  error Found incompatible module.
```

Also updated the version of loader-utils to address security vulnerability (static analysis was failing otherwise).

Note: it would have been great to be able to specify the version range for loader-utils but this is currently not supported: https://github.com/yarnpkg/yarn/issues/5794