### PR TITLE
Standards mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "@apollo/client": "^3.5.10",
         "@babel/polyfill": "^7.2.5",
         "@babel/runtime": "^7.12.5",
-        "@jahia/data-helper": "^1.0.4",
+        "@jahia/data-helper": "^1.0.7",
         "@jahia/design-system-kit": "^1.1.11",
         "@jahia/icons": "^1.1.1",
         "@jahia/moonstone": "^1.0.0",

--- a/src/main/resources/root.jsp
+++ b/src/main/resources/root.jsp
@@ -10,6 +10,8 @@
 <%@ taglib prefix="user" uri="http://www.jahia.org/tags/user" %>
 <%@ taglib prefix="internal" uri="http://www.jahia.org/tags/internalLib" %>
 
+<!DOCTYPE html>
+
 <html>
 
 <head>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1351,10 +1351,10 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
-"@jahia/data-helper@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@jahia/data-helper/-/data-helper-1.0.4.tgz#1bfd8feb4ca1d61aadbfe00605d77ae7aeb82ef7"
-  integrity sha512-a1wp2ut0iYxpkJAPwnYONaqaP5Jv4gM6PRZOht8nJU7sBHot7lSb/AXehAyqOCUuX+DBrJoK6rXGGLL7AhHaHQ==
+"@jahia/data-helper@^1.0.7":
+  version "1.0.7"
+  resolved "https://npm.jahia.com/@jahia%2fdata-helper/-/data-helper-1.0.7.tgz#213d9e819781f9d70786fc3f3c07e8e2138fc025"
+  integrity sha512-sK+mBtVU1kwC4eS/IcRetbxyCJkY8H8clKa0/ETq6XUwWSYSB/AhXx4yD++mkXw3OJzxwV0I88vLatHJVm022Q==
   dependencies:
     apollo-cache "^1.3.4"
     apollo-client "^2.6.8"


### PR DESCRIPTION


## Description

Run in standards mode as some software may not function properly. For example, tinyMCE detects quirks mode and refuses to function logging message that it only runs in standards mode. From documentation on quirks mode: 'The general purpose of quirks mode is that it’s a compatibility mode for IE5' I don't think we need compatibility with IE5 at this point, so we should probably be safe running in standards mode.