### PR TITLE
Use standards mode

### DIFF
--- a/src/main/resources/root.jsp
+++ b/src/main/resources/root.jsp
@@ -10,6 +10,8 @@
 <%@ taglib prefix="user" uri="http://www.jahia.org/tags/user" %>
 <%@ taglib prefix="internal" uri="http://www.jahia.org/tags/internalLib" %>
 
+<!DOCTYPE html>
+
 <html>
 
 <head>


### PR DESCRIPTION

## Description

Run in standards mode as some software may not function properly. For example, tinyMCE detects quirks mode and refuses to function logging message that it only runs in standards mode. From documentation on quirks mode: 'The general purpose of quirks mode is that it’s a compatibility mode for IE5' I don't think we need compatibility with IE5 at this point, so we should probably be safe running in standards mode.