### PR TITLE
BACKLOG-21615: add timestamp to scripts name to avoid to clear browse…

### DIFF
--- a/src/main/java/org/jahia/modules/appshell/Main.java
+++ b/src/main/java/org/jahia/modules/appshell/Main.java
@@ -201,6 +201,7 @@ public class Main extends HttpServlet implements BundleListener {
             LocalizationContext ctx = new LocalizationContext(rb);
             wrapper.setAttribute("resourceBundleContext", ctx);
 
+            wrapper.setAttribute("appShellScriptsTimestamp", System.currentTimeMillis());
             setCustomAttributes(currentUser, wrapper);
 
             List<String> scripts = (appInfo != null && appInfo.getScripts().get(APPS) != null) ? appInfo.getScripts().get(APPS) : new ArrayList<>();

--- a/src/main/resources/META-INF/urlrewrite-app-shell.xml
+++ b/src/main/resources/META-INF/urlrewrite-app-shell.xml
@@ -37,7 +37,7 @@
     <rule>
         <name>js config (inbound)</name>
         <note>Handles checksum for the resources of the js configs for the proper cache support</note>
-        <from>^/modules/(.*)/configs/(.*)\.js(\?.*){0,1}$</from>
+        <from>^/modules/(.*)/configs/(.*)\.js(\?v=.*){0,1}$</from>
         <to last="true">/modules/$1/configs/$2.jsp</to>
     </rule>
 

--- a/src/main/resources/META-INF/urlrewrite-app-shell.xml
+++ b/src/main/resources/META-INF/urlrewrite-app-shell.xml
@@ -37,7 +37,7 @@
     <rule>
         <name>js config (inbound)</name>
         <note>Handles checksum for the resources of the js configs for the proper cache support</note>
-        <from>^/modules/(.*)/configs/(.*)\.v[0-9a-f]+\.js$</from>
+        <from>^/modules/(.*)/configs/(.*)\.js(\?.*){0,1}$</from>
         <to last="true">/modules/$1/configs/$2.jsp</to>
     </rule>
 
@@ -45,8 +45,7 @@
         <name>js config (outbound)</name>
         <note>Handles checksum for the resources of the js configs for the proper cache support</note>
         <from>^(/[\p{Alnum}\-_]*)?(/modules/(.*)/configs/(.*)\.jsp)$</from>
-        <run class="org.jahia.services.seo.urlrewrite.ResourceChecksumCalculator" method="calculateChecksum(HttpServletRequest, String, String)"/>
-        <to last="true" encode="false">$1/modules/$3/configs/$4.v%{attribute:ResourceChecksumCalculator.checksum}.js</to>
+        <to last="true" encode="false">$1/modules/$3/configs/$4.js?v=%{attribute:appShellScriptsTimestamp}</to>
     </outbound-rule>
 
 </urlrewrite>


### PR DESCRIPTION
…r cache

https://jira.jahia.org/browse/BACKLOG-21615

Add timestamp value as parameter of script urls too avoid to have to clear the browser cache when changing a configuration which is  loaded trough a JSP file in a module