### PR TITLE
QA-15281 : remove deprecated js libs from shared libs.

### DIFF
--- a/webpack.shared.js
+++ b/webpack.shared.js
@@ -27,12 +27,7 @@ const sharedDeps = [
     '@apollo/client',
     '@apollo/react-common',
     '@apollo/react-components',
-    '@apollo/react-hooks',
-
-    // DEPRECATED JAHIA PACKAGES
-    '@jahia/design-system-kit',
-    '@jahia/react-material',
-    '@jahia/icons'
+    '@apollo/react-hooks'
 ];
 
 const singletonDeps = [


### PR DESCRIPTION
https://jira.jahia.org/browse/QA-15281
With firefox 130, in certain conditions on Windows, Jahia never ends loading because of circular reference in @jahia/react-components and @jahia/design-system-kit
As those libs are not used by the app-shell we can remove them from the shared libs. 
Note that they are still exposed by the DDL compatibility code. 