### PR TITLE
QA-15281 : upgrade design-system-kit

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "@babel/polyfill": "^7.2.5",
         "@babel/runtime": "^7.12.5",
         "@jahia/data-helper": "^1.0.4",
-        "@jahia/design-system-kit": "^1.1.11",
+        "@jahia/design-system-kit": "^1.2.1",
         "@jahia/icons": "^1.1.1",
         "@jahia/moonstone": "^1.0.0",
         "@jahia/moonstone-alpha": "^1.0.0",

--- a/webpack.shared.js
+++ b/webpack.shared.js
@@ -27,7 +27,11 @@ const sharedDeps = [
     '@apollo/client',
     '@apollo/react-common',
     '@apollo/react-components',
-    '@apollo/react-hooks'
+    '@apollo/react-hooks',
+
+    // DEPRECATED JAHIA PACKAGES (since 2019)
+    // @jahia/design-system-kit is required to provide the 1.2.1 version that fixes an issue with firefox 130 on windows.
+    '@jahia/design-system-kit'
 ];
 
 const singletonDeps = [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1388,10 +1388,10 @@
     lodash "^4.17.13"
     react-apollo "^3.1.3"
 
-"@jahia/design-system-kit@^1.1.11":
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/@jahia/design-system-kit/-/design-system-kit-1.1.11.tgz#bb1d561da538e6158c0e53a969934e3023d3d6a1"
-  integrity sha512-oyh5y/0biSBl4J8592XGLpnZYqnREKXsJDwNYUyz/+fKhrAkkF1ve4XVFEqUBRJEIXA0Lafk0WznuXFcWAndqg==
+"@jahia/design-system-kit@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@jahia/design-system-kit/-/design-system-kit-1.2.1.tgz#6108bc4af2f30ee61f46b02dc90ff31a5f6a12db"
+  integrity sha512-gJSH0UudanuByoEEWElgVDOCMwQcFTsRX6/Dw4pL026EixlrBEOX/0KfY0ppQ8v0Uef26QQ88K4N0BbEf3EhAA==
   dependencies:
     "@material-ui/core" "^3.9.3"
     classnames "^2.2.6"


### PR DESCRIPTION
https://jira.jahia.org/browse/QA-15281
The initial issue from QA-15281 can still happen has the circle dependency between @jahia/react-material and @jahia/design-system-kit may exists between two modules (such as jcontent and sdl-generator modules) 
The latest version of design-system-kit removes that circle dependency, providing it from the app-shell in the shared modules fixes any usage. 